### PR TITLE
fix: ensure 100vh minimum for page content height

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -88,6 +88,7 @@ const Layout: FunctionComponent = ({ children }) => {
             z-index: 10;
             position: relative;
             background: #171717;
+            min-height: 100vh;
           }
           button {
             right: 0;


### PR DESCRIPTION
Primarily addresses an issue on mobile devices where the content element would not use up full height available if the content itself did not extend to bottom of viewable area.