### PR TITLE
fix: ensure home gallery effect is cleaned up

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,13 +33,17 @@ const Index = () => {
   }, [])
 
   useEffect(() => {
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       if (currentImage === GALLERY_IMAGES.length - 1) {
         return setCurrentImage(0)
       }
 
       setCurrentImage(currentImage + 1)
     }, 5000)
+
+    return function cleanup() {
+      clearTimeout(timeout)
+    }
   }, [currentImage, setCurrentImage])
 
   interface ImageDimensions {


### PR DESCRIPTION
Returns a cleanup function from home page gallery effect so that a state update is not attempted after the component has been unmounted.