### PR TITLE
feat: social media share card config

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -60,10 +60,12 @@ const Layout: FunctionComponent = ({ children }) => {
     <ParallaxProvider>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="twitter:card" content="summary_large_image" />
         <meta
           name="description"
           content={META_DESCRIPTION}
         />
+        <meta property="og:type" content="business" />
       </Head>
       <div className="container">
         <div style={{ opacity: !navHasOpened ? 0 : 1 }}>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -51,6 +51,8 @@ const About = () => {
     <Layout>
       <Head>
         <title>About | Goliath Construction</title>
+        <meta property="og:title" content="About | Goliath Construction" />
+        <meta property="og:image" content={PAGE_IMAGE} />
       </Head>
       <ParallaxBanner {...parallaxProps } />
       <PageContentContainer>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -167,6 +167,8 @@ const Index = () => {
     <Layout>
       <Head>
         <title>Goliath Construction</title>
+        <meta property="og:title" content="Goliath Construction" />
+        <meta property="og:image" content={GALLERY_IMAGES[0]} />
       </Head>
       <div className="home-content">
         <div className="home-images-wrapper">

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -99,6 +99,8 @@ const Projects = () => {
     <Layout>
       <Head>
         <title>Projects | Goliath Construction</title>
+        <meta property="og:title" content="Projects | Goliath Construction" />
+        <meta property="og:image" content={PARALLAX_IMAGE} />
       </Head>
       <ParallaxBanner {...parallaxProps} />
       <PageContentContainer>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -156,6 +156,8 @@ const ProjectDetailsPage = ({ project }: ProjectDetailsPageComponent) => {
     <Layout>
       <Head>
         <title>{project.name} | Goliath Construction</title>
+        <meta property="og:title" content={project.name} />
+        <meta property="og:image" content={project.thumbnailImage} />
       </Head>
       <ParallaxBanner {...parallaxProps} />
       <PageContentContainer>

--- a/pages/references.tsx
+++ b/pages/references.tsx
@@ -39,6 +39,8 @@ const References = () => {
     <Layout>
       <Head>
         <title>References | Goliath Construction</title>
+        <meta property="og:title" content="References | Goliath Construction" />
+        <meta property="og:image" content={PARALLAX_IMAGE} />
       </Head>
       <ParallaxBanner {...parallaxProps} />
       <PageContentContainer>


### PR DESCRIPTION
Configures meta tags in head element to display a proper/nice preview on facebook and twitter